### PR TITLE
Add placeholder selector to the grammar

### DIFF
--- a/src/sass.grammar
+++ b/src/sass.grammar
@@ -141,7 +141,8 @@ selector {
   AttributeSelector { selector? !attribute "[" AttributeName { identifier } (MatchOp value)? "]" } |
   ChildSelector { selector !structure ChildOp selector } |
   DescendantSelector { selector !structure descendantOp selector } |
-  SiblingSelector { selector !structure SiblingOp selector }
+  SiblingSelector { selector !structure SiblingOp selector } |
+  PlaceholderSelector { "%" ClassName { identifier } }
 }
 
 pseudoClassWithArg {

--- a/test/selector.txt
+++ b/test/selector.txt
@@ -153,3 +153,19 @@ StyleSheet(RuleSet(ClassSelector(ClassName),Block(
 
 StyleSheet(RuleSet(ClassSelector(ClassName),Block(
   RuleSet(DescendantSelector(ClassSelector(ClassName),NestingSelector),Block))))
+
+# Placeholder selector
+
+%theme-button {}
+
+==>
+
+StyleSheet(RuleSet(PlaceholderSelector(ClassName), Block))
+
+# Placeholder selector after class selector
+
+.primary-button, %theme-button {}
+
+==>
+
+StyleSheet(RuleSet(ClassSelector(ClassName),",",PlaceholderSelector(ClassName), Block))


### PR DESCRIPTION
Fixes a syntax error on encountering `%` of [placeholder selector](https://sass-lang.com/documentation/style-rules/placeholder-selectors/)